### PR TITLE
do_split more fine granular to keep number of tasks smaller

### DIFF
--- a/examples/fibonacci.cpp
+++ b/examples/fibonacci.cpp
@@ -227,7 +227,7 @@ int hpx_main(int argc, char **argv)
            std::int64_t res = fib_runner(n);
            fib_elapsed = t.elapsed_microseconds();
            std::cout << "fib(" << n << ") = " << res << " taking " << fib_elapsed << " microseconds. Iter: " << i << "\n";
-           usleep(2000000);
+           usleep(1000000);
         }
         allscale::scheduler::stop();
     }

--- a/examples/fibonacci.cpp
+++ b/examples/fibonacci.cpp
@@ -227,6 +227,7 @@ int hpx_main(int argc, char **argv)
            std::int64_t res = fib_runner(n);
            fib_elapsed = t.elapsed_microseconds();
            std::cout << "fib(" << n << ") = " << res << " taking " << fib_elapsed << " microseconds. Iter: " << i << "\n";
+           usleep(2000000);
         }
         allscale::scheduler::stop();
     }

--- a/examples/fibonacci.cpp
+++ b/examples/fibonacci.cpp
@@ -212,7 +212,7 @@ std::int64_t fib_runner(std::int64_t n)
 int hpx_main(int argc, char **argv)
 {
 
-//    allscale::components::monitor_component_init();
+    allscale::components::monitor_component_init();
 
     // start allscale scheduler ...
     allscale::scheduler::run(hpx::get_locality_id());
@@ -228,6 +228,7 @@ int hpx_main(int argc, char **argv)
            std::int64_t res = fib_runner(n);
            fib_elapsed = t.elapsed_microseconds();
            std::cout << "fib(" << n << ") = " << res << " taking " << fib_elapsed << " microseconds. Iter: " << i << "\n";
+           usleep(2000000);
         }
         allscale::scheduler::stop();
     }

--- a/src/components/scheduler_component.cpp
+++ b/src/components/scheduler_component.cpp
@@ -31,7 +31,7 @@ namespace allscale { namespace components {
                 &scheduler::collect_counters,
                 this
             ),
-            2000,
+            1000,
             "scheduler::collect_counters",
             true
         )
@@ -119,7 +119,7 @@ namespace allscale { namespace components {
         }
 
         timer_.start();
-        //throttle_timer_.start();
+        throttle_timer_.start();
         std::cout
             << "Scheduler with rank "
             << rank_ << " created (" << left_ << " " << right_ << ")!\n";
@@ -226,7 +226,7 @@ namespace allscale { namespace components {
             total_idle_rate_ += idle_rates_[num_thread];
             total_length_ += queue_length_[num_thread];
 
-             //std::cout << "Collecting[" << num_thread << "] " << idle_rates_[num_thread] << " " << queue_length_[num_thread] << "\n";
+           //  std::cout << "Collecting[" << num_thread << "] " << idle_rates_[num_thread] << " " << queue_length_[num_thread] << "\n";
         }
 
         total_idle_rate_ = total_idle_rate_ / num_threads_;

--- a/src/components/scheduler_component.cpp
+++ b/src/components/scheduler_component.cpp
@@ -31,7 +31,7 @@ namespace allscale { namespace components {
                 &scheduler::collect_counters,
                 this
             ),
-            1000,
+            2000,
             "scheduler::collect_counters",
             true
         )
@@ -119,7 +119,7 @@ namespace allscale { namespace components {
         }
 
         timer_.start();
-        throttle_timer_.start();
+        //throttle_timer_.start();
         std::cout
             << "Scheduler with rank "
             << rank_ << " created (" << left_ << " " << right_ << ")!\n";
@@ -178,12 +178,23 @@ namespace allscale { namespace components {
     {
         std::unique_lock<mutex_type> l(counters_mtx_);
         // Do we have enough tasks in the system?
-        if (total_length_ < num_threads_ * 10)
+        if (total_length_ < num_threads_ * 5)
         {
             return total_idle_rate_ >= 10.0;
         }
+        if (total_length_ < num_threads_ * 10)
+        {
+            //std::cout << total_length_ << " " << total_idle_rate_ << "\n";
+            //return total_idle_rate_ >= 10.0;
+            return total_idle_rate_ < 10.0;
+        }
+        if (total_length_ < num_threads_ * 20)
+        {
+            //std::cout << total_length_ << " " << total_idle_rate_ << "\n";
+            return total_idle_rate_ < 5.0;
+        }
 
-        return total_idle_rate_ < 10.0;
+        return total_idle_rate_ < 2.0;
     }
 
     bool scheduler::collect_counters()
@@ -215,7 +226,7 @@ namespace allscale { namespace components {
             total_idle_rate_ += idle_rates_[num_thread];
             total_length_ += queue_length_[num_thread];
 
-           //  std::cout << "Collecting[" << num_thread << "] " << idle_rates_[num_thread] << " " << queue_length_[num_thread] << "\n";
+             //std::cout << "Collecting[" << num_thread << "] " << idle_rates_[num_thread] << " " << queue_length_[num_thread] << "\n";
         }
 
         total_idle_rate_ = total_idle_rate_ / num_threads_;

--- a/src/components/scheduler_component.cpp
+++ b/src/components/scheduler_component.cpp
@@ -30,7 +30,7 @@ namespace allscale { namespace components {
                 &scheduler::collect_counters,
                 this
             ),
-            1000,
+            2000,
             "scheduler::collect_counters",
             true
         )
@@ -119,7 +119,7 @@ namespace allscale { namespace components {
         }
 
         timer_.start();
-        throttle_timer_.start();
+        //throttle_timer_.start();
         std::cout
             << "Scheduler with rank "
             << rank_ << " created (" << left_ << " " << right_ << ")!\n";
@@ -180,13 +180,24 @@ namespace allscale { namespace components {
 //        hpx::util::ignore_while_checking<std::unique_lock<mutex_type>> il(&l);
         std::size_t num_threads = hpx::get_num_worker_threads();
         // Do we have enough tasks in the system?
-        if (total_length_ < num_threads * 10)
+        //std::cout << total_length_ << " " << total_idle_rate_ <<  " " << w.id().name() << "\n";
+        if (total_length_ < num_threads * 5)
         {
-//             std::cout << total_length_ << " " << total_idle_rate_ << "\n";
             return total_idle_rate_ >= 10.0;
         }
+        if (total_length_ < num_threads * 10)
+        {
+            //std::cout << total_length_ << " " << total_idle_rate_ << "\n";
+            //return total_idle_rate_ >= 10.0;
+            return total_idle_rate_ < 10.0;
+        }
+        if (total_length_ < num_threads * 20)
+        {
+            //std::cout << total_length_ << " " << total_idle_rate_ << "\n";
+            return total_idle_rate_ < 5.0;
+        }
 
-        return total_idle_rate_ < 10.0;
+        return total_idle_rate_ < 2.0;
     }
 
     bool scheduler::collect_counters()
@@ -224,7 +235,7 @@ namespace allscale { namespace components {
             total_idle_rate_ += idle_rates_[num_thread];
             total_length_ += queue_length_[num_thread];
 
-           //  std::cout << "Collecting[" << num_thread << "] " << idle_rates_[num_thread] << " " << queue_length_[num_thread] << "\n";
+             //std::cout << "Collecting[" << num_thread << "] " << idle_rates_[num_thread] << " " << queue_length_[num_thread] << "\n";
         }
 
         total_idle_rate_ = total_idle_rate_ / num_threads;

--- a/src/components/scheduler_component.cpp
+++ b/src/components/scheduler_component.cpp
@@ -31,7 +31,7 @@ namespace allscale { namespace components {
                 &scheduler::collect_counters,
                 this
             ),
-            2000,
+            1000,
             "scheduler::collect_counters",
             true
         )
@@ -119,7 +119,7 @@ namespace allscale { namespace components {
         }
 
         timer_.start();
-        //throttle_timer_.start();
+        throttle_timer_.start();
         std::cout
             << "Scheduler with rank "
             << rank_ << " created (" << left_ << " " << right_ << ")!\n";
@@ -184,13 +184,10 @@ namespace allscale { namespace components {
         }
         if (total_length_ < num_threads_ * 10)
         {
-            //std::cout << total_length_ << " " << total_idle_rate_ << "\n";
-            //return total_idle_rate_ >= 10.0;
             return total_idle_rate_ < 10.0;
         }
         if (total_length_ < num_threads_ * 20)
         {
-            //std::cout << total_length_ << " " << total_idle_rate_ << "\n";
             return total_idle_rate_ < 5.0;
         }
 
@@ -226,7 +223,7 @@ namespace allscale { namespace components {
             total_idle_rate_ += idle_rates_[num_thread];
             total_length_ += queue_length_[num_thread];
 
-             //std::cout << "Collecting[" << num_thread << "] " << idle_rates_[num_thread] << " " << queue_length_[num_thread] << "\n";
+           //  std::cout << "Collecting[" << num_thread << "] " << idle_rates_[num_thread] << " " << queue_length_[num_thread] << "\n";
         }
 
         total_idle_rate_ = total_idle_rate_ / num_threads_;


### PR DESCRIPTION
do_split more fine granular, to keep number of tasks smaller/reasonable when launched with many threads.