### PR TITLE
CMake: Simplify source list in src/CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,43 +1,30 @@
+set(_srcs
+    data_item_reference.cpp
+    data_requirements_check.cpp
+    monitor.cpp
+    resilience.cpp
+    scheduler.cpp
+    this_work_item.cpp
+    treeture.cpp
+    components/monitor_component.cpp
+    components/resilience_component.cpp
+    components/scheduler_component.cpp
+    components/scheduler_network.cpp
+    components/util/graph_colouring.cpp
+    detail/work_item_impl_base.cpp
+)
 
 if(CPUFREQ_FOUND)
-    add_hpx_component(
-      allscale
-      SOURCES
-        data_requirements_check.cpp
-        monitor.cpp
-        resilience.cpp
-        scheduler.cpp
-        this_work_item.cpp
-        treeture.cpp
-        data_item_reference.cpp
-        detail/work_item_impl_base.cpp
-        components/scheduler_component.cpp
-        components/scheduler_network.cpp
-        components/util/graph_colouring.cpp
+    set(_srcs ${_srcs}
         components/util/hardware_reconf.cpp
-        components/monitor_component.cpp
-        components/resilience_component.cpp
     )
+else()
+    MESSAGE(STATUS "Didnt find CPUFREQ, will compile without hardware reconf support")
+endif()
+
+add_hpx_component(allscale SOURCES ${_srcs})
+
+if(CPUFREQ_FOUND)
     target_link_libraries(allscale_component ${CPUFREQ_LIBRARIES})
     target_compile_definitions(allscale_component PUBLIC ALLSCALE_HAVE_CPUFREQ)
-
-elseif(NOT CPUFREQ_FOUND)
-    MESSAGE(STATUS "Didnt find CPUFREQ, will compile without hardware reconf support")
-     add_hpx_component(
-      allscale
-      SOURCES
-        monitor.cpp
-        resilience.cpp
-        scheduler.cpp
-        this_work_item.cpp
-        treeture.cpp
-        data_item_reference.cpp
-        detail/work_item_impl_base.cpp
-        components/scheduler_component.cpp
-        components/scheduler_network.cpp
-        components/util/graph_colouring.cpp
-        components/monitor_component.cpp
-        components/resilience_component.cpp
-    )
-    target_link_libraries(allscale_component )
 endif()


### PR DESCRIPTION
This commit removes the duplicated source file list in `src/CMakeLists.txt`. Entries only relevant when CPUFREQ is found, are added to the single list.