### PR TITLE
Add ALLSCALE_WITH_EXAMPLES build flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 2.8)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
+option(ALLSCALE_WITH_EXAMPLES "Build AllScale Runtime Examples" ON)
+
 find_package(HPX REQUIRED)
 find_package(CPUFREQ)
 
@@ -32,7 +34,10 @@ add_definitions(-DALLSCALE_WITH_HPX)
 include_directories(${CMAKE_SOURCE_DIR} ${ALLSCALE_API_DIR}/code/utils/include ${ALLSCALE_API_DIR}/code/api/include)
 
 add_subdirectory(src)
-add_subdirectory(examples)
+
+if(ALLSCALE_WITH_EXAMPLES)
+  add_subdirectory(examples)
+endif()
 
 if(ALLSCALE_WITH_TESTS)
   enable_testing()


### PR DESCRIPTION
Currently the examples are always built. This is not needed when building the AllScale runtime via the compiler. This PR adds a flag to enable / disable examples.

Note that no default value is defined as there is also no default value defined for `ALLSCALE_WITH_TESTS`.